### PR TITLE
fix crash when CedarX registers are located abof 0x7fffffff

### DIFF
--- a/libcedarv/android/adapter/libve_adapter.c
+++ b/libcedarv/android/adapter/libve_adapter.c
@@ -120,7 +120,7 @@ s32 cedardev_init(void)
 		return -1;
 
 	ioctl(cedarv_osal_ctx->fd, IOCTL_GET_ENV_INFO, (unsigned long)&cedarv_osal_ctx->env_info);
-	cedarv_osal_ctx->env_info.address_macc = (unsigned int)mmap(NULL, 2048, PROT_READ | PROT_WRITE, MAP_SHARED, cedarv_osal_ctx->fd, (int)cedarv_osal_ctx->env_info.address_macc);
+	cedarv_osal_ctx->env_info.address_macc = (unsigned int)mmap(NULL, 2048, PROT_READ | PROT_WRITE, MAP_SHARED, cedarv_osal_ctx->fd, (off_t)cedarv_osal_ctx->env_info.address_macc);
 
 	pthread_mutex_init(&cedarv_osal_mutex, NULL);
 

--- a/libcedarv/linux-armel/adapter/libve_adapter.c
+++ b/libcedarv/linux-armel/adapter/libve_adapter.c
@@ -123,7 +123,7 @@ s32 cedardev_init(void)
 		return -1;
 
 	ioctl(cedarv_osal_ctx->fd, IOCTL_GET_ENV_INFO, (unsigned long)&cedarv_osal_ctx->env_info);
-	cedarv_osal_ctx->env_info.address_macc = (unsigned int)mmap(NULL, 2048, PROT_READ | PROT_WRITE, MAP_SHARED, cedarv_osal_ctx->fd, (int)cedarv_osal_ctx->env_info.address_macc);
+	cedarv_osal_ctx->env_info.address_macc = (unsigned int)mmap(NULL, 2048, PROT_READ | PROT_WRITE, MAP_SHARED, cedarv_osal_ctx->fd, (off_t)cedarv_osal_ctx->env_info.address_macc);
 
 	pthread_mutex_init(&cedarv_osal_mutex, NULL);
 

--- a/libcedarv/linux-armhf/adapter/libve_adapter.c
+++ b/libcedarv/linux-armhf/adapter/libve_adapter.c
@@ -121,7 +121,7 @@ s32 cedardev_init(void)
 		return -1;
 
 	ioctl(cedarv_osal_ctx->fd, IOCTL_GET_ENV_INFO, (unsigned long)&cedarv_osal_ctx->env_info);
-	cedarv_osal_ctx->env_info.address_macc = (unsigned int)mmap(NULL, 2048, PROT_READ | PROT_WRITE, MAP_SHARED, cedarv_osal_ctx->fd, (int)cedarv_osal_ctx->env_info.address_macc);
+	cedarv_osal_ctx->env_info.address_macc = (unsigned int)mmap(NULL, 2048, PROT_READ | PROT_WRITE, MAP_SHARED, cedarv_osal_ctx->fd, (off_t)cedarv_osal_ctx->env_info.address_macc);
 
 	pthread_mutex_init(&cedarv_osal_mutex, NULL);
 


### PR DESCRIPTION
When the hardware registers of the CedarX are located on physical addresses above 0x7fffffff, the last argument of mmap() becomes negative. This causes mmap() to fail and since there is no error checking, libcedarx will crash.
